### PR TITLE
Add missing basic flags and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+
+- Added missing basic options to `SwiftyESBuild.RunOption`.
+- Added documentation to every case in `SwiftyESBuild.RunOption`.
+- Added a "Get started" page to the documentation catalog.
+
 ### Changed
 
 - Don't start `esbuild` in a new process to ensure it gets killed when the Swift process (parent process) exits [commit](h) by [@pepicrft](https://github.com/pepicrft)

--- a/Package.swift
+++ b/Package.swift
@@ -12,13 +12,14 @@ let package = Package(
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "SwiftyESBuild",
-            targets: ["SwiftyESBuild"]),
+            targets: ["SwiftyESBuild"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.5.2")),
         .package(url: "https://github.com/apple/swift-docc-plugin", .upToNextMinor(from: "1.3.0")),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMinor(from: "1.5.2")),
-        .package(url: "https://github.com/swift-server/async-http-client.git", .upToNextMinor(from: "1.18.0"))
+        .package(url: "https://github.com/swift-server/async-http-client.git", .upToNextMinor(from: "1.18.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -28,11 +29,12 @@ let package = Package(
             dependencies: [
                 .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
                 .product(name: "Logging", package: "swift-log"),
-                .product(name: "AsyncHTTPClient", package: "async-http-client")
+                .product(name: "AsyncHTTPClient", package: "async-http-client"),
             ]
         ),
         .testTarget(
             name: "SwiftyESBuildTests",
-            dependencies: ["SwiftyESBuild", .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core")]),
+            dependencies: ["SwiftyESBuild", .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core")]
+        ),
     ]
 )

--- a/Sources/SwiftyESBuild/ArchitectureDetector.swift
+++ b/Sources/SwiftyESBuild/ArchitectureDetector.swift
@@ -2,19 +2,19 @@ import Foundation
 import TSCBasic
 import TSCUtility
 
-public enum CpuArchitecture: String, Hashable  {
-    case arm = "arm"
-    case arm64   = "arm64"
-    case armv7   = "armv7"
-    case x64 = "x64"
-    case x86_64   = "x86_64"
-    case ia32 = "ia32"
-    case loong64 = "loong64"
-    case mips64el = "mips64el"
-    case ppc64 = "ppc64"
-    case riscv64 = "riscv64"
-    case s390x = "s390x"
-    
+public enum CpuArchitecture: String, Hashable {
+    case arm
+    case arm64
+    case armv7
+    case x64
+    case x86_64
+    case ia32
+    case loong64
+    case mips64el
+    case ppc64
+    case riscv64
+    case s390x
+
     /**
      Maps the architecture to the values used by ESBuild: https://github.com/evanw/esbuild/tree/main/npm/%40esbuild
      */

--- a/Sources/SwiftyESBuild/Documentation.docc/Index.md
+++ b/Sources/SwiftyESBuild/Documentation.docc/Index.md
@@ -1,0 +1,32 @@
+# Get started
+
+`SwiftyESBuild` is a Swift Package that wraps [ESBuild](https://esbuild.github.io) to ease bringing bundling capabilities to Swift on Server apps.
+
+
+## Usage
+
+First, you need to add `SwiftyESBuild` as a dependency in your project's `Package.swift`:
+
+```swift
+.package(url: "https://github.com/tuist/SwiftyESBuild.git", .upToNextMinor(from: "0.1.0"))
+```
+
+Once added, you'll create an instance of `SwiftyESBuild` specifying the version you'd like to use and where you'd like it to be downloaded.
+
+```swift
+let esbuild = SwiftyESBuild(version: .latest, directory: "./cache")
+```
+
+If you don't pass any argument, it defaults to the latest version in the system's default temporary directory. If you work in a team, we recommend fixing the version to minimize non-determinism across environments.
+
+### Running ESBuild
+
+To run ESBuild you need to invoke the `run` function:
+
+```swift
+import TSCBasic // AbsolutePath
+
+let entryPointPath = AbsolutePath(validating: "/project/index.js")
+let outputBundlePath = AbsolutePath(validating: "/projects/build/index.js")
+try await esbuild.run(entryPoint: entryPointPath, options: .bundle, .outfile(outputBundlePath))
+```

--- a/Sources/SwiftyESBuild/Downloader.swift
+++ b/Sources/SwiftyESBuild/Downloader.swift
@@ -1,40 +1,38 @@
+import AsyncHTTPClient
 import Foundation
 import Logging
-import TSCBasic
-import AsyncHTTPClient
 import NIOCore
 import NIOFoundationCompat
-import TSCUtility
 import TSCBasic
+import TSCUtility
 
 /**
  It represents the payload returned by the https://registry.npmjs.org/{package} URL. SwiftyESBuild uses the information in the payload to determine the latest version and the URL from where we can download a given version.
  */
 struct NPMPackage: Decodable {
-    
     struct DistTags: Decodable {
         let latest: String
     }
-    
+
     struct Version: Decodable {
         struct Dist: Decodable {
             let tarball: String
             let shasum: String
             let integrity: String
         }
+
         let dist: Dist
     }
-    
+
     let name: String
     let distTags: DistTags
     let versions: [String: Version]
-    
-    enum CodingKeys : String, CodingKey {
+
+    enum CodingKeys: String, CodingKey {
         case distTags = "dist-tags"
         case versions
         case name
     }
-    
 }
 
 /*
@@ -45,17 +43,17 @@ enum DownloaderError: LocalizedError {
      This error is thrown when we can't determine the NPM packag ename.
      */
     case unableToDeterminePackageName
-    
+
     /**
      This error is thrown when the version can't be found in the payload returned by the NPM registry.
      */
     case versionNotFound(String)
-    
+
     var errorDescription: String? {
         switch self {
         case .unableToDeterminePackageName:
             return "We were unable to determine ESBuild's package name for this architecture and OS."
-        case .versionNotFound(let version):
+        case let .versionNotFound(version):
             return "The payload returned by https://registry.npmjs.org/@esbuild/{os}-{arch} doesn't contain the version \(version)"
         }
     }
@@ -76,38 +74,39 @@ class Downloader: Downloading {
     let architectureDetector: ArchitectureDetecting
     let logger: Logger
     let tar: Tarring
-    
+
     /**
      Returns the default directory where ESBuild binaries should be downloaded.
      */
     static func defaultDownloadDirectory() -> AbsolutePath {
-        return try! localFileSystem.tempDirectory.appending(component: "SwiftyESBuild")
+        try! localFileSystem.tempDirectory.appending(component: "SwiftyESBuild")
     }
-    
+
     init(architectureDetector: ArchitectureDetecting = ArchitectureDetector(),
-         tar: Tarring = Tar()) {
+         tar: Tarring = Tar())
+    {
         self.architectureDetector = architectureDetector
-        self.logger = Logger(label: "io.tuist.SwiftyESBuild.Downloader")
+        logger = Logger(label: "io.tuist.SwiftyESBuild.Downloader")
         self.tar = tar
     }
-    
+
     func download() async throws -> TSCBasic.AbsolutePath {
         try await download(version: .latest, directory: Downloader.defaultDownloadDirectory())
     }
-    
+
     func download(version: ESBuildVersion,
                   directory: AbsolutePath) async throws -> AbsolutePath
     {
-        let npmPackage = try await self.npmPackage()
+        let npmPackage = try await npmPackage()
         let expectedVersion = try await versionToDownload(version: version, npmPackage: npmPackage)
         let binaryPath = directory.appending(components: [expectedVersion, "esbuild"])
         if localFileSystem.exists(binaryPath) { return binaryPath }
         try await downloadBinary(npmPackage: npmPackage, version: expectedVersion, to: binaryPath)
         return binaryPath
     }
-    
+
     // MARK: - Private
-    
+
     private func downloadBinary(npmPackage: NPMPackage, version: String, to downloadPath: AbsolutePath) async throws {
         if !localFileSystem.exists(downloadPath.parentDirectory) {
             logger.debug("Creating directory \(downloadPath.parentDirectory)")
@@ -116,14 +115,14 @@ class Downloader: Downloading {
         guard let npmVersion = npmPackage.versions[version]?.dist else {
             throw DownloaderError.versionNotFound(version)
         }
-        
+
         logger.debug("Downloading \(npmPackage.name) from \(npmVersion.tarball)...")
         let client = HTTPClient(eventLoopGroupProvider: .createNew)
 
         do {
             try await withTemporaryDirectory(removeTreeOnDeinit: true) { tmpDir in
                 let tgzPath = tmpDir.appending(component: "esbuild.tgz")
-                
+
                 let request = try HTTPClient.Request(url: URL(string: npmVersion.tarball)!)
                 let delegate = try FileDownloadDelegate(path: tgzPath.pathString, reportProgress: { [weak self] in
                     if let totalBytes = $0.totalBytes {
@@ -131,26 +130,26 @@ class Downloader: Downloading {
                     }
                     self?.logger.debug("Downloaded \($0.receivedBytes) bytes so far")
                 })
-                
+
                 try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                     client.execute(request: request, delegate: delegate).futureResult.whenComplete { result in
                         switch result {
-                        case .success(_):
-                                Task {
-                                    do {
-                                        // TODO: Do checksum validation
-                                        try await self.tar.extract(tar: tgzPath)
-                                        let binaryPath = tgzPath.parentDirectory.appending(.init("package/bin/esbuild"))
-                                        try localFileSystem.chmod(.executable, path: binaryPath)
-                                        try localFileSystem.move(from: binaryPath, to: downloadPath)
-                                        continuation.resume()
-                                    } catch {
-                                        print(error)
-                                        continuation.resume(throwing: error)
-                                        return
-                                    }
+                        case .success:
+                            Task {
+                                do {
+                                    // TODO: Do checksum validation
+                                    try await self.tar.extract(tar: tgzPath)
+                                    let binaryPath = tgzPath.parentDirectory.appending(.init("package/bin/esbuild"))
+                                    try localFileSystem.chmod(.executable, path: binaryPath)
+                                    try localFileSystem.move(from: binaryPath, to: downloadPath)
+                                    continuation.resume()
+                                } catch {
+                                    print(error)
+                                    continuation.resume(throwing: error)
+                                    return
                                 }
-                        case .failure(let error):
+                            }
+                        case let .failure(error):
                             continuation.resume(throwing: error)
                         }
                     }
@@ -162,13 +161,13 @@ class Downloader: Downloading {
         }
         try await client.shutdown()
     }
-    
+
     /**
      Returns the version that should be downloaded.
      */
     private func versionToDownload(version: ESBuildVersion, npmPackage: NPMPackage) async throws -> String {
         switch version {
-        case .fixed(let rawVersion):
+        case let .fixed(rawVersion):
             if rawVersion.starts(with: "v") {
                 return rawVersion
             } else {
@@ -180,7 +179,7 @@ class Downloader: Downloading {
         case .latest: return npmPackage.distTags.latest
         }
     }
-    
+
     /**
      It returns the NPM package metadata from the https://registry.npmjs.org/{package-name} URL.
      ESBuild has a package per architecture and OS supported. For example, we can obtain the metadata
@@ -188,14 +187,14 @@ class Downloader: Downloading {
      https://registry.npmjs.org/@esbuild/darwin-arm64
      */
     private func npmPackage() async throws -> NPMPackage {
-        guard let npmPackageName = self.npmPackageName() else {
+        guard let npmPackageName = npmPackageName() else {
             throw DownloaderError.unableToDeterminePackageName
         }
         let packageURL = "https://registry.npmjs.org/\(npmPackageName)"
         logger.debug("Getting the package metadata from \(packageURL)")
-        
+
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
-        
+
         var package: NPMPackage!
         do {
             var request = HTTPClientRequest(url: packageURL)
@@ -208,12 +207,12 @@ class Downloader: Downloading {
             try await httpClient.shutdown()
             throw error
         }
-        
+
         try await httpClient.shutdown()
-        
+
         return package
     }
-    
+
     /**
         It returns the name of the NPM package for the current OS and architecture. The name follows the convention:
         @esbuild/{os}-{arch}
@@ -225,11 +224,11 @@ class Downloader: Downloading {
         }
         var os: String!
         #if os(Windows)
-        os = "windows"
+            os = "windows"
         #elseif os(Linux)
-        os = "linux"
+            os = "linux"
         #else
-        os = "darwin"
+            os = "darwin"
         #endif
         return "@esbuild/\(os!)-\(architecture)"
     }

--- a/Sources/SwiftyESBuild/ESBuildVersion.swift
+++ b/Sources/SwiftyESBuild/ESBuildVersion.swift
@@ -5,11 +5,11 @@ import Foundation
  */
 public enum ESBuildVersion {
     /**
-    It pulls the latest version.
-     */
+     It pulls the latest version.
+      */
     case latest
     /**
-    It pulls a fixed version.
-     */
+     It pulls a fixed version.
+      */
     case fixed(String)
 }

--- a/Sources/SwiftyESBuild/SwiftyESBuild.swift
+++ b/Sources/SwiftyESBuild/SwiftyESBuild.swift
@@ -8,7 +8,7 @@ public class SwiftyESBuild {
     private let directory: AbsolutePath
     private let downloader: Downloading
     private let executor: Executing
-    
+
     /**
      Default initializer.
      - Parameters:
@@ -18,7 +18,7 @@ public class SwiftyESBuild {
     public convenience init(version: ESBuildVersion = .latest, directory: AbsolutePath) {
         self.init(version: version, directory: directory, downloader: Downloader(), executor: Executor())
     }
-    
+
     /**
      Default initializer.
      - Parameters:
@@ -27,61 +27,64 @@ public class SwiftyESBuild {
     public convenience init(version: ESBuildVersion = .latest) {
         self.init(version: version, directory: Downloader.defaultDownloadDirectory(), downloader: Downloader(), executor: Executor())
     }
-    
+
     private init(version: ESBuildVersion,
-         directory: AbsolutePath,
-         downloader: Downloading,
-         executor: Executing)
+                 directory: AbsolutePath,
+                 downloader: Downloading,
+                 executor: Executing)
     {
         self.version = version
         self.directory = directory
         self.downloader = downloader
         self.executor = executor
     }
-    
+
     /**
      Downloads the executable if needed and runs it with the given options. By default it runs the executable from the directory containing the entry point Javascript module.
-     
+
      - Parameters:
-        - entryPoint: The path to the entry point Javascript module that ESBuild will use to traverse the module graph and generate the output bundle.
-        - options: A set of options to pass to the ESBuild executable to configure the bundling.
+     - entryPoint: The path to the entry point Javascript module that ESBuild will use to traverse the module graph and generate the output bundle.
+     - options: A set of options to pass to the ESBuild executable to configure the bundling.
      */
     public func run(entryPoint: AbsolutePath,
-                    options: RunOption...) async throws {
-        return try await run(entryPoint: entryPoint, directory: entryPoint.parentDirectory, options: options)
+                    options: RunOption...) async throws
+    {
+        try await run(entryPoint: entryPoint, directory: entryPoint.parentDirectory, options: options)
     }
 
     /**
      Downloads the executable if needed and runs it with the given options.
-     
+
      - Parameters:
-        - entryPoint: The path to the entry point Javascript module that ESBuild will use to traverse the module graph and generate the output bundle.
-        - directory: Working directory from where to run the ESBuild executable.
-        - options: A set of options to pass to the ESBuild executable to configure the bundling.
+     - entryPoint: The path to the entry point Javascript module that ESBuild will use to traverse the module graph and generate the output bundle.
+     - directory: Working directory from where to run the ESBuild executable.
+     - options: A set of options to pass to the ESBuild executable to configure the bundling.
      */
     public func run(entryPoint: AbsolutePath,
                     directory: AbsolutePath,
-                    options: RunOption...) async throws {
-        return try await run(entryPoint: entryPoint, directory: directory, options: options)
+                    options: RunOption...) async throws
+    {
+        try await run(entryPoint: entryPoint, directory: directory, options: options)
     }
-    
+
     /**
      Downloads the executable if needed and runs it with the given options.
-     
+
      - Parameters:
-        - entryPoint: The path to the entry point Javascript module that ESBuild will use to traverse the module graph and generate the output bundle.
-        - directory: Working directory from where to run the ESBuild executable.
-        - options: A set of options to pass to the ESBuild executable to configure the bundling.
+     - entryPoint: The path to the entry point Javascript module that ESBuild will use to traverse the module graph and generate the output bundle.
+     - directory: Working directory from where to run the ESBuild executable.
+     - options: A set of options to pass to the ESBuild executable to configure the bundling.
      */
     public func run(entryPoint: AbsolutePath,
                     directory: AbsolutePath,
-                    options: [RunOption]) async throws {
+                    options: [RunOption]) async throws
+    {
         let executablePath = try await download()
         var arguments = [entryPoint.pathString]
         arguments.append(contentsOf: options.flatMap(\.flag))
         try await executor.run(executablePath: executablePath, directory: directory, arguments: arguments)
     }
-    
+
     /**
      Downloads the Tailwind portable executable
      */
@@ -90,181 +93,371 @@ public class SwiftyESBuild {
     }
 }
 
-extension Set where Element == SwiftyESBuild.RunOption {
+extension Set<SwiftyESBuild.RunOption> {
     /**
      Returns the flags to pass to the Tailwind CLI when invoking the `init` command.
      */
     var executableFlags: [String] {
-        return self.map(\.flag).flatMap({$0})
+        map(\.flag).flatMap { $0 }
     }
 }
 
 public extension SwiftyESBuild {
     /**
+     An enum that represents the various JavaScript module systems supported by ESBuild.
+     */
+    enum Format: String {
+        case iife
+        case esm
+        case cjs
+    }
+
+    /**
+     An enum that represents the loaders supported by ESBuild.
+     */
+    enum Loader: String {
+        case base64
+        case binary
+        case copy
+        case css
+        case dataurl
+        case empty
+        case file
+        case js
+        case json
+        case jsx
+        case text
+        case ts
+        case tsx
+    }
+
+    /**
+     An enum that represents the JavaScript environments that ESBuild can target.
+     */
+    enum Target: String {
+        case es2017
+        case chrome58
+        case safari11
+        case edge16
+        case node10
+        case ie9
+        case opera45
+        case esnext
+    }
+
+    /**
+     An enum that represents the platforms that ESBuild can output Javascript for.
+     */
+    enum Platform: String {
+        case browser
+        case node
+        case neutral
+    }
+
+    /**
+     An enum that represents the various options that can be passed as `--packages` flag to the ESBuild CLI.
+     */
+    enum Packages: String {
+        case external
+    }
+
+    /**
+     An enum that represents the various options that can be passed as `--sourcemap` flag to the ESBuild CLI.
+     You can read more about the options in the [official documentation.](https://esbuild.github.io/api/#sourcemap)
+     */
+    enum Sourcemap: String {
+        case linked
+        case external
+        case inline
+        case both
+    }
+
+    /**
      An enum that captures all the options that that you can pass to the ESBuild executable.
      */
     enum RunOption: Hashable {
-        /**
-         Bundle all dependencies into the output files
-         Flag: --bundle
-         */
-        case bundle
-
-        /**
-         The output file (for one entry point)
-         Flag --outfile
-         */
-        case outfile(AbsolutePath)
-        
         /**
          Passes the arguments as raw values to the executable.
          {...arguments}
          */
         case arguments([String])
-        
+
         /**
-         Substitute substituted with substitute while parsing
-         Flag: --define
+         To bundle a file means to inline any imported dependencies into the file itself. This process is recursive so dependencies of dependencies (and so on) will also be inlined. By default esbuild will not bundle the input files.
+         - [Documentation](https://esbuild.github.io/api/#bundle)
+         - **Flag:** --bundle
+         */
+        case bundle
+
+        /**
+         This option sets the output file name for the build operation. This is only applicable if there is a single entry point. If there are multiple entry points, you must use the outdir option instead to specify an output directory.
+         - [Documentation](https://esbuild.github.io/api/#outfile)
+         - **Flag:** --outfile
+         */
+        case outfile(AbsolutePath)
+
+        /**
+         This feature provides a way to replace global identifiers with constant expressions. It can be a way to change the behavior some code between builds without changing the code itself.
+
+         - [Documentation](https://esbuild.github.io/api/#define)
+         - **Flag:** `--define`
+
+         ## CLI Example
+         ```bash
+         echo 'hooks = DEBUG && require("hooks")' | esbuild --define:DEBUG=true
+         hooks = require("hooks");
+         ```
          */
         case define(substituted: String, substitute: String)
-        
+
         /**
-         Excludes the Javascript module that matches the given wildcard from the bundle:
-         Flag: --external
+         You can mark a file or a package as external to exclude it from your build. Instead of being bundled, the import will be preserved (using `require` for the `iife` and `cjs` formats and using `import` for the `esm` format) and will be evaluated at run time instead.
+
+         This has several uses. First of all, it can be used to trim unnecessary code from your bundle for a code path that you know will never be executed. For example, a package may contain code that only runs in node but you will only be using that package in the browser. It can also be used to import code in node at run time from a package that cannot be bundled. For example, the `fsevents` package contains a native extension, which esbuild doesn't support.
+
+         - [Documentation](https://esbuild.github.io/api/#external)
+         - **Flag:** `--external`
+
+         ## CLI Example
+
+         ```bash
+         echo 'require("fsevents")' > app.js
+         esbuild app.js --bundle --external:fsevents --platform=node
+         // app.js
+         require("fsevents");
+         ```
          */
         case external(wildcard: String)
-        
+
+        /**
+         This sets the output format for the generated JavaScript files. There are currently three possible values that can be configured: `iife`, `cjs`, and `esm`. When no output format is specified, esbuild picks an output format for you if bundling is enabled (as described below), or doesn't do any format conversion if [bundling](https://esbuild.github.io/api/#bundle) is disabled.
+
+         - [Documentation](https://esbuild.github.io/api/#format)
+         - **Flag:** `--format`
+         */
+        case format(Format)
+
+        /**
+         This option changes how a given input file is interpreted. For example, the [js](https://esbuild.github.io/content-types/#javascript) loader interprets the file as JavaScript and the css loader interprets the file as CSS. See the [content types](https://esbuild.github.io/content-types/) page for a complete list of all built-in loaders.
+
+         Configuring a loader for a given file type lets you load that file type with an import statement or a require call.
+
+         - [Documentation](https://esbuild.github.io/api/#loader)
+         - **Flags:** `--loader`
+
+         ## CLI Example
+         ```js
+         import url from './example.png'
+         let image = new Image
+         image.src = url
+         document.body.appendChild(image)
+
+         import svg from './example.svg'
+         let doc = new DOMParser().parseFromString(svg, 'application/xml')
+         let node = document.importNode(doc.documentElement, true)
+         document.body.appendChild(node)
+         ```
+         */
+        case loader(extension: String, loader: Loader)
+
+        /**
+         When enabled, the generated code will be minified instead of pretty-printed. Minified code is generally equivalent to non-minified code but is smaller, which means it downloads faster but is harder to debug. Usually you minify code in production but not in development.
+
+         - [Documentation](https://esbuild.github.io/api/#minify)
+         - **Flag:** `--minify`
+
+         ### CLI Example
+         ```bash
+         echo 'fn = obj => { return obj.x }' | esbuild --minify
+         fn=n=>n.x;
+         ```
+         */
+        case minify
+
+        /**
+         This option sets the output directory for the build operation.
+
+         The output directory will be generated if it does not already exist, but it will not be cleared if it already contains some files. Any generated files will silently overwrite existing files with the same name. You should clear the output directory yourself before running esbuild if you want the output directory to only contain files from the current run of esbuild.
+
+         If your build contains multiple entry points in separate directories, the directory structure will be replicated into the output directory starting from the [lowest common ancestor](https://en.wikipedia.org/wiki/Lowest_common_ancestor) directory among all input entry point paths. For example, if there are two entry points `src/home/index.ts` and `src/about/index.ts`, the output directory will contain `home/index.js` and `about/index.js`. If you want to customize this behavior, you should change the [outbase directory](https://esbuild.github.io/api/#outbase).
+
+         ## CLI Example
+
+         - [Documentation](https://esbuild.github.io/api/#outdir)
+         - **Flag:** `--outdir`
+
+         ```bash
+         esbuild app.js --bundle --outdir=out
+         ```
+         */
+        case outdir(AbsolutePath)
+
+        /**
+         Enabling watch mode tells esbuild to listen for changes on the file system and to automatically rebuild whenever a file changes that could invalidate the build.
+
+         - [Documentation](https://esbuild.github.io/api/#watch)
+         - **Flag:** `--watch`
+
+         ## CLI Example
+
+         ```bash
+         esbuild app.js --outfile=out.js --bundle --watch
+         # [watch] build finished, watching for changes...
+         ```
+         */
+        case watch(forever: Bool = false)
+        /**
+         Source maps can make it easier to debug your code. They encode the information necessary to translate from a line/column offset in a generated output file back to a line/column offset in the corresponding original input file. This is useful if your generated code is sufficiently different from your original code (e.g. your original code is TypeScript or you enabled [minification](https://esbuild.github.io/api/#minify)). This is also useful if you prefer looking at individual files in your browser's developer tools instead of one big bundled file.
+
+         Note that source map output is supported for both JavaScript and CSS, and the same options apply to both. Everything below that talks about `.js` files also applies similarly to `.css` files.
+
+         - [Documentation](https://esbuild.github.io/api/#sourcemap)
+         - **Flag:** `--sourcemap`
+
+         ## CLI Example
+
+         ```bash
+         esbuild app.ts --sourcemap --outfile=out.js
+         ```
+         */
+        case sourcemap(Sourcemap? = nil)
+        /**
+         This enables "code splitting" which serves two purposes:
+
+         - Code shared between multiple entry points is split off into a separate shared file that both entry points import. That way if the user first browses to one page and then to another page, they don't have to download all of the JavaScript for the second page from scratch if the shared part has already been downloaded and cached by their browser.
+
+         - Code referenced through an asynchronous import() expression will be split off into a separate file and only loaded when that expression is evaluated. This allows you to improve the initial download time of your app by only downloading the code you need at startup, and then lazily downloading additional code if needed later.
+
+         Without code splitting enabled, an `import()` expression becomes `Promise.resolve().then(() => require())` instead. This still preserves the asynchronous semantics of the expression but it means the imported code is included in the same bundle instead of being split off into a separate file.
+
+         When you enable code splitting you must also configure the output directory using the outdir setting:
+
+         - [Documentation](https://esbuild.github.io/api/#splitting)
+         - **Flag:** `--splitting`
+
+         ## CLI Example
+         ```bash
+         esbuild home.ts about.ts --bundle --splitting --outdir=out --format=esm
+         ```
+         */
+        case splitting
+        /**
+         This sets the target environment for the generated JavaScript and/or CSS code. It tells esbuild to transform JavaScript syntax that is too new for these environments into older JavaScript syntax that will work in these environments. For example, the `??` operator was introduced in Chrome 80 so esbuild will convert it into an equivalent (but more verbose) conditional expression when targeting Chrome 79 or earlier.
+
+         - [Documentation](https://esbuild.github.io/api/#target)
+         - **Flag:** `--target`
+
+         ## CLI Example
+         ```bash
+         esbuild app.js --target=es2020,chrome58,edge16,firefox57,node12,safari11
+         ```
+         */
+        case target([Target])
+        /**
+         By default, esbuild's bundler is configured to generate code intended for the browser. If your bundled code is intended to run in node instead, you should set the platform to node.
+
+         - [Documentation](https://esbuild.github.io/api/#platform)
+         - **Flag:** `--platform`
+
+         ## CLI Example
+         ```bash
+         esbuild app.js --bundle --platform=node
+         ```
+         */
+        case platform(Platform)
+
+        /**
+         Serve mode starts a web server that serves your code to your browser on your device.
+
+         - [Documentation](https://esbuild.github.io/api/#serve)
+         - **Flag:** `--serve`
+
+         ## CLI Example
+
+         ```bash
+         # Enable serve mode
+         --serve
+
+         # Set the port
+         --serve=9000
+
+         # Set the host and port (IPv4)
+         --serve=127.0.0.1:9000
+
+         # Set the host and port (IPv6)
+         --serve=[::1]:9000
+
+         # Set the directory to serve
+         --servedir=www
+
+         # Enable HTTPS
+         --keyfile=your.key --certfile=your.cert
+         ```
+         */
+        case serve(String? = nil)
+        /**
+         Use this setting to exclude all of your package's dependencies from the bundle. This is useful when bundling for node because many npm packages use node-specific features that esbuild doesn't support while bundling (such as `__dirname`, `import.meta.url`, `fs.readFileSync`, and *.node native binary modules).
+
+         - [Documentation](https://esbuild.github.io/api/#packages)
+         - **Flag:** `--packages`
+
+         ## CLI Example
+         ```bash
+         esbuild app.js --bundle --packages=external
+         ```
+
+         */
+        case packages(Packages)
+
         /**
          The CLI flag that represents the option.
          */
         var flag: [String] {
             switch self {
             case .bundle: return ["--bundle"]
-            case .outfile(let outputFilePath):
+            case let .outfile(outputFilePath):
                 return ["--outfile=\(outputFilePath.pathString)"]
-            case .arguments(let arguments):
+            case let .arguments(arguments):
                 return arguments
-            case .define(let substituted, let substitute):
+            case let .define(substituted, substitute):
                 return ["--define:\(substituted)=\(substitute)"]
-            case .external(let wildcard):
+            case let .external(wildcard):
                 return ["--external:\(wildcard)"]
+            case let .format(format):
+                return ["--format=\(format.rawValue)"]
+            case let .loader(ext, loader):
+                return ["--loader:\(ext):\(loader.rawValue)"]
+            case .minify:
+                return ["--minify"]
+            case let .outdir(outDir):
+                return ["--outdir=\(outDir.pathString)"]
+            case let .watch(forever):
+                if forever {
+                    return ["--watch=forever"]
+                } else {
+                    return ["--watch"]
+                }
+            case let .sourcemap(sourcemap):
+                if let sourcemap {
+                    return ["--sourcemap=\(sourcemap.rawValue)"]
+                } else {
+                    return ["--sourcemap"]
+                }
+            case .splitting:
+                return ["--splitting"]
+            case let .target(targets):
+                return ["--target=\(targets.map(\.rawValue).joined(separator: ","))"]
+            case let .platform(platform):
+                return ["--platform=\(platform.rawValue)"]
+            case let .serve(serve):
+                if let serve {
+                    return ["--serve=\(serve)"]
+                } else {
+                    return ["--serve"]
+                }
+            case let .packages(packages):
+                return ["--packages=\(packages.rawValue)"]
             }
         }
     }
 }
-
-/**
- Simple options:
-   --bundle              Bundle all dependencies into the output files
-   --define:K=V          Substitute K with V while parsing
-   --external:M          Exclude module M from the bundle (can use * wildcards)
-   --format=...          Output format (iife | cjs | esm, no default when not
-                         bundling, otherwise default is iife when platform
-                         is browser and cjs when platform is node)
-   --loader:X=L          Use loader L to load file extension X, where L is
-                         one of: base64 | binary | copy | css | dataurl |
-                         empty | file | js | json | jsx | text | ts | tsx
-   --minify              Minify the output (sets all --minify-* flags)
-   --outdir=...          The output directory (for multiple entry points)
-   --outfile=...         The output file (for one entry point)
-   --packages=...        Set to "external" to avoid bundling any package
-   --platform=...        Platform target (browser | node | neutral,
-                         default browser)
-   --serve=...           Start a local HTTP server on this host:port for outputs
-   --sourcemap           Emit a source map
-   --splitting           Enable code splitting (currently only for esm)
-   --target=...          Environment target (e.g. es2017, chrome58, firefox57,
-                         safari11, edge16, node10, ie9, opera45, default esnext)
-   --watch               Watch mode: rebuild on file system changes (stops when
-                         stdin is closed, use "--watch=forever" to ignore stdin)
-
- Advanced options:
-   --allow-overwrite         Allow output files to overwrite input files
-   --analyze                 Print a report about the contents of the bundle
-                             (use "--analyze=verbose" for a detailed report)
-   --asset-names=...         Path template to use for "file" loader files
-                             (default "[name]-[hash]")
-   --banner:T=...            Text to be prepended to each output file of type T
-                             where T is one of: css | js
-   --certfile=...            Certificate for serving HTTPS (see also "--keyfile")
-   --charset=utf8            Do not escape UTF-8 code points
-   --chunk-names=...         Path template to use for code splitting chunks
-                             (default "[name]-[hash]")
-   --color=...               Force use of color terminal escapes (true | false)
-   --drop:...                Remove certain constructs (console | debugger)
-   --entry-names=...         Path template to use for entry point output paths
-                             (default "[dir]/[name]", can also use "[hash]")
-   --footer:T=...            Text to be appended to each output file of type T
-                             where T is one of: css | js
-   --global-name=...         The name of the global for the IIFE format
-   --ignore-annotations      Enable this to work with packages that have
-                             incorrect tree-shaking annotations
-   --inject:F                Import the file F into all input files and
-                             automatically replace matching globals with imports
-   --jsx-dev                 Use React's automatic runtime in development mode
-   --jsx-factory=...         What to use for JSX instead of React.createElement
-   --jsx-fragment=...        What to use for JSX instead of React.Fragment
-   --jsx-import-source=...   Override the package name for the automatic runtime
-                             (default "react")
-   --jsx-side-effects        Do not remove unused JSX expressions
-   --jsx=...                 Set to "automatic" to use React's automatic runtime
-                             or to "preserve" to disable transforming JSX to JS
-   --keep-names              Preserve "name" on functions and classes
-   --keyfile=...             Key for serving HTTPS (see also "--certfile")
-   --legal-comments=...      Where to place legal comments (none | inline |
-                             eof | linked | external, default eof when bundling
-                             and inline otherwise)
-   --log-level=...           Disable logging (verbose | debug | info | warning |
-                             error | silent, default info)
-   --log-limit=...           Maximum message count or 0 to disable (default 6)
-   --log-override:X=Y        Use log level Y for log messages with identifier X
-   --main-fields=...         Override the main file order in package.json
-                             (default "browser,module,main" when platform is
-                             browser and "main,module" when platform is node)
-   --mangle-cache=...        Save "mangle props" decisions to a JSON file
-   --mangle-props=...        Rename all properties matching a regular expression
-   --mangle-quoted=...       Enable renaming of quoted properties (true | false)
-   --metafile=...            Write metadata about the build to a JSON file
-                             (see also: https://esbuild.github.io/analyze/)
-   --minify-whitespace       Remove whitespace in output files
-   --minify-identifiers      Shorten identifiers in output files
-   --minify-syntax           Use equivalent but shorter syntax in output files
-   --out-extension:.js=.mjs  Use a custom output extension instead of ".js"
-   --outbase=...             The base path used to determine entry point output
-                             paths (for multiple entry points)
-   --preserve-symlinks       Disable symlink resolution for module lookup
-   --public-path=...         Set the base URL for the "file" loader
-   --pure:N                  Mark the name N as a pure function for tree shaking
-   --reserve-props=...       Do not mangle these properties
-   --resolve-extensions=...  A comma-separated list of implicit extensions
-                             (default ".tsx,.ts,.jsx,.js,.css,.json")
-   --servedir=...            What to serve in addition to generated output files
-   --source-root=...         Sets the "sourceRoot" field in generated source maps
-   --sourcefile=...          Set the source file for the source map (for stdin)
-   --sourcemap=external      Do not link to the source map with a comment
-   --sourcemap=inline        Emit the source map with an inline data URL
-   --sources-content=false   Omit "sourcesContent" in generated source maps
-   --supported:F=...         Consider syntax F to be supported (true | false)
-   --tree-shaking=...        Force tree shaking on or off (false | true)
-   --tsconfig=...            Use this tsconfig.json file instead of other ones
-   --version                 Print the current version (0.18.6) and exit
-
- Examples:
-   # Produces dist/entry_point.js and dist/entry_point.js.map
-   esbuild --bundle entry_point.js --outdir=dist --minify --sourcemap
-
-   # Allow JSX syntax in .js files
-   esbuild --bundle entry_point.js --outfile=out.js --loader:.js=jsx
-
-   # Substitute the identifier RELEASE for the literal true
-   esbuild example.js --outfile=out.js --define:RELEASE=true
-
-   # Provide input via stdin, get output via stdout
-   esbuild --minify --loader=ts < input.ts > output.js
-
-   # Automatically rebuild when input files are changed
-   esbuild app.ts --bundle --watch
-
-   # Start a local HTTP server for everything in "www"
-   esbuild app.ts --bundle --servedir=www --outdir=www/js
- */

--- a/Sources/SwiftyESBuild/Tar.swift
+++ b/Sources/SwiftyESBuild/Tar.swift
@@ -1,6 +1,6 @@
 import Foundation
-import TSCBasic
 import Logging
+import TSCBasic
 
 /**
  A protocol that defines the interface to extract the content from a tar file.
@@ -17,16 +17,16 @@ protocol Tarring {
  */
 class Tar: Tarring {
     let logger: Logger
-    
+
     /**
      Default constructor.
      */
     init() {
-        self.logger = Logger(label: "io.tuist.SwiftyESBuild.Tar")
+        logger = Logger(label: "io.tuist.SwiftyESBuild.Tar")
     }
-    
+
     func extract(tar: AbsolutePath) async throws {
-        let process = Process(arguments: ["/usr/bin/env","tar", "-xvf", tar.pathString], workingDirectory: tar.parentDirectory)
+        let process = Process(arguments: ["/usr/bin/env", "tar", "-xvf", tar.pathString], workingDirectory: tar.parentDirectory)
         _ = try process.launch()
         try await process.waitUntilExit()
     }

--- a/Tests/SwiftyESBuildTests/SwiftyESBuildTests.swift
+++ b/Tests/SwiftyESBuildTests/SwiftyESBuildTests.swift
@@ -1,7 +1,7 @@
-import XCTest
+@testable import SwiftyESBuild
 import TSCBasic
 import TSCUtility
-@testable import SwiftyESBuild
+import XCTest
 
 final class SwiftyESBuildTests: XCTestCase {
     func testExample() async throws {
@@ -10,7 +10,7 @@ final class SwiftyESBuildTests: XCTestCase {
             let subject = SwiftyESBuild(directory: tmpDir)
             let aModule = """
             import run from "./b.js"
-            
+
             run()
             """
             let bModule = """
@@ -23,12 +23,12 @@ final class SwiftyESBuildTests: XCTestCase {
             let outputBundlePath = tmpDir.appending(component: "output.js")
             try localFileSystem.writeFileContents(aModulePath, bytes: .init(encodingAsUTF8: aModule))
             try localFileSystem.writeFileContents(bModulePath, bytes: .init(encodingAsUTF8: bModule))
-            
+
             // When
             try await subject.run(entryPoint: aModulePath, options: .bundle, .outfile(outputBundlePath))
-            
+
             // Then
-            let content = String(bytes: try localFileSystem.readFileContents(outputBundlePath).contents, encoding: .utf8)
+            let content = try String(bytes: localFileSystem.readFileContents(outputBundlePath).contents, encoding: .utf8)
             XCTAssertTrue(content?.contains("console.log(\"esbuild\")") ?? false)
         }
     }


### PR DESCRIPTION
I'm adding missing basic flags to `SwiftyESBuild.RunOption` and I've taken the opportunity to document every case and add a "Get started" page to the documentation catalog.