### PR TITLE
Documentation Fixes

### DIFF
--- a/Sources/SwiftyESBuild/SwiftyESBuild.swift
+++ b/Sources/SwiftyESBuild/SwiftyESBuild.swift
@@ -12,8 +12,8 @@ public class SwiftyESBuild {
     /**
      Default initializer.
      - Parameters:
-     - version: The version of Tailwind to use. You can specify a fixed version or use the latest one.
-     - directory: The directory where the executables will be downloaded. When not provided, it defaults to the system's default temporary directory.
+       - version: The version of Tailwind to use. You can specify a fixed version or use the latest one.
+       - directory: The directory where the executables will be downloaded. When not provided, it defaults to the system's default temporary directory.
      */
     public convenience init(version: ESBuildVersion = .latest, directory: AbsolutePath) {
         self.init(version: version, directory: directory, downloader: Downloader(), executor: Executor())
@@ -22,7 +22,7 @@ public class SwiftyESBuild {
     /**
      Default initializer.
      - Parameters:
-     - version: The version of ESBuild to use. You can specify a fixed version or use the latest one.
+       - version: The version of ESBuild to use. You can specify a fixed version or use the latest one.
      */
     public convenience init(version: ESBuildVersion = .latest) {
         self.init(version: version, directory: Downloader.defaultDownloadDirectory(), downloader: Downloader(), executor: Executor())
@@ -43,8 +43,8 @@ public class SwiftyESBuild {
      Downloads the executable if needed and runs it with the given options. By default it runs the executable from the directory containing the entry point Javascript module.
 
      - Parameters:
-     - entryPoint: The path to the entry point Javascript module that ESBuild will use to traverse the module graph and generate the output bundle.
-     - options: A set of options to pass to the ESBuild executable to configure the bundling.
+       - entryPoint: The path to the entry point Javascript module that ESBuild will use to traverse the module graph and generate the output bundle.
+       - options: A set of options to pass to the ESBuild executable to configure the bundling.
      */
     public func run(entryPoint: AbsolutePath,
                     options: RunOption...) async throws
@@ -56,9 +56,9 @@ public class SwiftyESBuild {
      Downloads the executable if needed and runs it with the given options.
 
      - Parameters:
-     - entryPoint: The path to the entry point Javascript module that ESBuild will use to traverse the module graph and generate the output bundle.
-     - directory: Working directory from where to run the ESBuild executable.
-     - options: A set of options to pass to the ESBuild executable to configure the bundling.
+       - entryPoint: The path to the entry point Javascript module that ESBuild will use to traverse the module graph and generate the output bundle.
+       - directory: Working directory from where to run the ESBuild executable.
+       - options: A set of options to pass to the ESBuild executable to configure the bundling.
      */
     public func run(entryPoint: AbsolutePath,
                     directory: AbsolutePath,
@@ -71,9 +71,9 @@ public class SwiftyESBuild {
      Downloads the executable if needed and runs it with the given options.
 
      - Parameters:
-     - entryPoint: The path to the entry point Javascript module that ESBuild will use to traverse the module graph and generate the output bundle.
-     - directory: Working directory from where to run the ESBuild executable.
-     - options: A set of options to pass to the ESBuild executable to configure the bundling.
+       - entryPoint: The path to the entry point Javascript module that ESBuild will use to traverse the module graph and generate the output bundle.
+       - directory: Working directory from where to run the ESBuild executable.
+       - options: A set of options to pass to the ESBuild executable to configure the bundling.
      */
     public func run(entryPoint: AbsolutePath,
                     directory: AbsolutePath,

--- a/Sources/SwiftyESBuild/SwiftyESBuild.swift
+++ b/Sources/SwiftyESBuild/SwiftyESBuild.swift
@@ -12,7 +12,7 @@ public class SwiftyESBuild {
     /**
      Default initializer.
      - Parameters:
-       - version: The version of Tailwind to use. You can specify a fixed version or use the latest one.
+       - version: The version of ESBuild to use. You can specify a fixed version or use the latest one.
        - directory: The directory where the executables will be downloaded. When not provided, it defaults to the system's default temporary directory.
      */
     public convenience init(version: ESBuildVersion = .latest, directory: AbsolutePath) {
@@ -86,7 +86,7 @@ public class SwiftyESBuild {
     }
 
     /**
-     Downloads the Tailwind portable executable
+     Downloads the ESBuild portable executable.
      */
     private func download() async throws -> AbsolutePath {
         try await downloader.download(version: version, directory: directory)
@@ -95,7 +95,7 @@ public class SwiftyESBuild {
 
 extension Set<SwiftyESBuild.RunOption> {
     /**
-     Returns the flags to pass to the Tailwind CLI when invoking the `init` command.
+     Returns the flags to pass to the ESBuild CLI when invoking the `init` command.
      */
     var executableFlags: [String] {
         map(\.flag).flatMap { $0 }


### PR DESCRIPTION
Indents the parameters in the documentation so that they are recognized as such and replaces mentions of "Tailwind" with "ESBuild".

The current lack of indentation means that the parameters are treated as part of the discussion (at least in Xcode 15.1):

![Before2](https://github.com/tuist/SwiftyESBuild/assets/422815/dd05e033-a3ba-4f2e-9636-6d542f2dff44)

This fixes that by indenting them:

![After2](https://github.com/tuist/SwiftyESBuild/assets/422815/4f53cca9-86f2-49c1-bbd8-5e8806e5f1d1)
