### PR TITLE
Fix Error Downloading Fixed ESBuild Version

### DIFF
--- a/Sources/SwiftyESBuild/Downloader.swift
+++ b/Sources/SwiftyESBuild/Downloader.swift
@@ -169,12 +169,12 @@ class Downloader: Downloading {
         switch version {
         case let .fixed(rawVersion):
             if rawVersion.starts(with: "v") {
-                return rawVersion
-            } else {
                 /**
-                 Releases on GitHub are prefixed with "v" so we need to include it.
+                 Versions on the npm Registry are not prefixed with "v" so we need to remove it.
                  */
-                return "v\(rawVersion)"
+                return String(rawVersion.dropFirst())
+            } else {
+                return rawVersion
             }
         case .latest: return npmPackage.distTags.latest
         }

--- a/Tests/SwiftyESBuildTests/DownloaderTests.swift
+++ b/Tests/SwiftyESBuildTests/DownloaderTests.swift
@@ -1,0 +1,20 @@
+@testable import SwiftyESBuild
+import TSCBasic
+import TSCUtility
+import XCTest
+
+final class DownloaderTests: XCTestCase {
+    func testDownloadFixedVersion() async throws {
+        try await withTemporaryDirectory(removeTreeOnDeinit: true) { tmpDir in
+            // Given
+            let subject = Downloader()
+            let version = "0.19.11"
+
+            // When
+            let path = try await subject.download(version: .fixed(version), directory: tmpDir)
+
+            // Then
+            XCTAssertTrue(path.pathString.hasSuffix("/\(version)/esbuild"))
+        }
+    }
+}


### PR DESCRIPTION
Fixes error when using `ESBuildVersion.fixed` and adds tests for downloading a fixed version.

Unlike GitHub, releases on the npm Registry are not prefixed with `v`. This means that attempts to use a stable version with `let esbuild = SwiftyESBuild(version: .fixed("0.19.11"))` fail:

```
The payload returned by https://registry.npmjs.org/@esbuild/{os}-{arch} doesn't contain the version v0.19.11
```

This updates `Downloader.versionToDownload(version:, npmPackage:)` to not prepend `v` to the `rawVersion` and removes it if present.

